### PR TITLE
Some quick bug fixes after rebasing on Kokkos dev branch

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
@@ -217,13 +217,13 @@ __inline__ __device__ T atomic_fetch_and(volatile T* const,
 }
 #endif
 
+#endif // !defined(_NVHPC_CUDA)
+
 // Simpler version of atomic_fetch_and without the fetch
 template <typename T>
 KOKKOS_INLINE_FUNCTION void atomic_and(volatile T* const dest, const T src) {
   (void)atomic_fetch_and(dest, src);
 }
-
-#endif // !defined(_NVHPC_CUDA)
 
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
@@ -193,13 +193,13 @@ __inline__ __device__ T atomic_fetch_or(volatile T* const,
 }
 #endif
 
+#endif // !defined(_NVHPC_CUDA)
+
 // Simpler version of atomic_fetch_or without the fetch
 template <typename T>
 KOKKOS_INLINE_FUNCTION void atomic_or(volatile T* const dest, const T src) {
   (void)atomic_fetch_or(dest, src);
 }
-
-#endif // !defined(_NVHPC_CUDA)
 
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -84,6 +84,10 @@ uint64_t clock_tic() noexcept {
   // Return value of 64-bit hi-res clock register.
   if target (nv::target::is_device) {
     return clock64();
+  } else {
+    return (uint64_t)std::chrono::high_resolution_clock::now()
+        .time_since_epoch()
+        .count();
   }
 
 #elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -621,6 +621,7 @@ TEST(TEST_CATEGORY, mathematical_functions_exponential_functions) {
   TEST_MATH_FUNCTION(exp)({-98.l, -7.6l, -.54l, 3.2l, 1.l, -0.l});
 #endif
 
+#ifndef _NVHPC_CUDA // exp2 not implemented in device code
   TEST_MATH_FUNCTION(exp2)({-9, -8, -7, -6, -5, 4, 3, 2, 1, 0});
   TEST_MATH_FUNCTION(exp2)({-9l, -8l, -7l, -6l, -5l, 4l, 3l, 2l, 1l, 0l});
   TEST_MATH_FUNCTION(exp2)({-9ll, -8ll, -7ll, -6ll, -5ll, 4ll, 3ll, 2ll, 1ll});
@@ -631,6 +632,7 @@ TEST(TEST_CATEGORY, mathematical_functions_exponential_functions) {
   TEST_MATH_FUNCTION(exp2)({-98., -7.6, -.54, 3.2, 1., -0.});
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
   TEST_MATH_FUNCTION(exp2)({-98.l, -7.6l, -.54l, 3.2l, 1.l, -0.l});
+#endif
 #endif
 
   TEST_MATH_FUNCTION(expm1)({-9, -8, -7, -6, -5, 4, 3, 2, 1, 0});


### PR DESCRIPTION
Fix some merge errors.  Disable tests of exp2, since that is not yet implemented in device code with nvc++.